### PR TITLE
Added RetrieveAddresses definition

### DIFF
--- a/LBNet/LBNet.def
+++ b/LBNet/LBNet.def
@@ -38,3 +38,4 @@ EXPORTS
 	UDPGetRemotePort
 	UDPConnectFrom
 	ConnectFrom
+	RetrieveAddresses


### PR DESCRIPTION
This is part of a dirty attempt to get a list of IP addresses on the PC and return them (as a string with each IP address on a new line... because I don't know how else to do it), and then be able to specify whichever one of these we choose when creating a listening socket to bind to a specific IP address instead of being at the mercy of whichever one getaddrinfo() finds first. At least I think that's how it works.